### PR TITLE
Fixed array parsing

### DIFF
--- a/lib/stanza.js
+++ b/lib/stanza.js
@@ -89,7 +89,7 @@ module.exports = function (JXT, opts) {
                     if (val.length > 0) {
                         var vals = [];
                         for (var n in val) {
-                            var nval = val[n];
+                            var nval = n;
                             if (nval.toJSON !== undefined) {
                                 vals.push(nval.toJSON());
                             } else {


### PR DESCRIPTION
For loop provides actual object, not index in this case.